### PR TITLE
Cleanup and add traversaro as mantainer

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,11 @@
+c_compiler:
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2017
 jsoncpp:
 - 1.8.4
 libcurl:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tobias-Fischer @seanyen
+* @Tobias-Fischer @seanyen @traversaro

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About libignition-fuel-tools5
 =============================
 
-Home: https://bitbucket.org/ignitionrobotics/ign-fuel-tools
+Home: https://github.com/ignitionrobotics/ign-fuel-tools
 
 Package license: Apache-2.0
 
@@ -149,4 +149,5 @@ Feedstock Maintainers
 
 * [@Tobias-Fischer](https://github.com/Tobias-Fischer/)
 * [@seanyen](https://github.com/seanyen/)
+* [@traversaro](https://github.com/traversaro/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,4 @@
 conda_forge_output_validation: true
+bot:
+  abi_migration_branches:
+    - "v8"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,21 +14,19 @@ source:
       - fix_ignition_cmake_version.patch
 
 build:
-  number: 1
-  skip: false
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:
-    - {{ compiler('cxx') }}  # [not win]
-    - {{ compiler('c') }}    # [not win]
-    - vs2017_win-64          # [win64]
-    - vs2017_win-32          # [win32]
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - cmake
     - ninja
-    - pkg-config             # [not win]
+    - pkg-config
   host:
+    - libignition-math6
     - libignition-msgs6
     - libignition-common3
     - libignition-tools1
@@ -55,7 +53,7 @@ test:
     - if exist %PREFIX%\\Library\\include\\ignition\fuel_tools{{ major_version }}\ignition\fuel_tools.hh (exit 0) else (exit 1)  # [win]
 
 about:
-  home: https://bitbucket.org/ignitionrobotics/ign-fuel-tools
+  home: https://github.com/ignitionrobotics/ign-fuel-tools
   license: Apache-2.0
   license_file: LICENSE
   summary: Ignition Fuel Tools is composed by a client library and command line tools for interacting with Ignition Fuel servers.
@@ -64,3 +62,4 @@ extra:
   recipe-maintainers:
     - seanyen
     - Tobias-Fischer
+    - traversaro


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Main changes:
* Add migration also for v4 branch
* Add explicit dependency on ignition-math6 (it will be only effective on the next v5 release, see https://github.com/ignitionrobotics/ign-fuel-tools/pull/151, but better to add it now as it is already a transitive dependency, and it will be easy to forget to add when a new release is done a the regro bot will bump the version)