### PR TITLE
Remove v5 from abi migration branches as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 bot:
   abi_migration_branches:
   - v4
-  - v5
   - v6
 build_platform:
   linux_aarch64: linux_64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - 219.patch
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md .
